### PR TITLE
squash: calling geocoding api even if the user has geocoding data saved

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,11 +17,7 @@ func main() {
 	key := userConfig.ApiKey
 	home := userConfig.HomeCity
 
-	userCity := flag.String(
-		"c",
-		fmt.Sprintf("%s,%s,%s", home.City, home.State, home.Country),
-		"Enter the city where you would like to look up the weather",
-	)
+	userCity := flag.String("c", "", "Enter the city where you would like to look up the weather")
 	flagKey := flag.String("k", "", "Enter your API key for the OpenWeatherMap API")
 	setHome := flag.Bool("h", false, "set the city specified with the -c flag as your home")
 	flag.Parse()


### PR DESCRIPTION
should fix #10 as well. Default value for city flag was causing the program to call the geocoding api with the saved detailed city name instead of using the saved geocoding data. This was only happening with cities that have duplicates because the detailed `city,state,country` format would only match exact duplicates.